### PR TITLE
feat(openai plugin): Add embedding support

### DIFF
--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 	"sync"
 
@@ -153,10 +152,6 @@ func DefineModel(g *genkit.Genkit, name string, info ai.ModelInfo) (ai.Model, er
 func DefineEmbedder(g *genkit.Genkit, name string) (ai.Embedder, error) {
 	if !state.initted {
 		panic("openai.Init not called")
-	}
-
-	if !slices.Contains(knownEmbedders, name) {
-		return nil, fmt.Errorf("unsupported embedder: %s", name)
 	}
 
 	return genkit.DefineEmbedder(g, provider, name, func(ctx context.Context, input *ai.EmbedRequest) (*ai.EmbedResponse, error) {

--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 
@@ -37,6 +38,12 @@ var (
 			Label:    "GPT-4o-mini",
 			Supports: &Multimodal,
 		},
+	}
+
+	knownEmbedders = []string{
+		openaiGo.EmbeddingModelTextEmbedding3Small,
+		openaiGo.EmbeddingModelTextEmbedding3Large,
+		openaiGo.EmbeddingModelTextEmbeddingAda002,
 	}
 )
 
@@ -81,6 +88,11 @@ func Init(ctx context.Context, g *genkit.Genkit, cfg *Config) error {
 	// define default models
 	for model, info := range supportedModels {
 		DefineModel(g, model, info)
+	}
+
+	// define default embedders
+	for _, embedder := range knownEmbedders {
+		DefineEmbedder(g, embedder)
 	}
 
 	return nil
@@ -135,4 +147,56 @@ func DefineModel(g *genkit.Genkit, name string, info ai.ModelInfo) (ai.Model, er
 
 		return resp, nil
 	}), nil
+}
+
+// DefineEmbedder defines an embedder with a given name.
+func DefineEmbedder(g *genkit.Genkit, name string) (ai.Embedder, error) {
+	if !state.initted {
+		panic("openai.Init not called")
+	}
+
+	if !slices.Contains(knownEmbedders, name) {
+		return nil, fmt.Errorf("unsupported embedder: %s", name)
+	}
+
+	return genkit.DefineEmbedder(g, provider, name, func(ctx context.Context, input *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+		var data openaiGo.EmbeddingNewParamsInputArrayOfStrings
+		for _, doc := range input.Documents {
+			for _, p := range doc.Content {
+				data = append(data, p.Text)
+			}
+		}
+
+		params := openaiGo.EmbeddingNewParams{
+			Input:          openaiGo.F[openaiGo.EmbeddingNewParamsInputUnion](data),
+			Model:          openaiGo.F(name),
+			EncodingFormat: openaiGo.F(openaiGo.EmbeddingNewParamsEncodingFormatFloat),
+		}
+
+		embeddingResp, err := state.client.Embeddings.New(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+
+		resp := &ai.EmbedResponse{}
+		for _, emb := range embeddingResp.Data {
+			embedding := make([]float32, len(emb.Embedding))
+			for i, val := range emb.Embedding {
+				embedding[i] = float32(val)
+			}
+			resp.Embeddings = append(resp.Embeddings, &ai.DocumentEmbedding{Embedding: embedding})
+		}
+		return resp, nil
+	}), nil
+}
+
+// IsDefinedEmbedder reports whether the named [Embedder] is defined by this plugin.
+func IsDefinedEmbedder(g *genkit.Genkit, name string) bool {
+	return genkit.IsDefinedEmbedder(g, provider, name)
+}
+
+// Embedder returns the [ai.Embedder] with the given name.
+// It returns nil if the embedder was not defined.
+func Embedder(g *genkit.Genkit, name string) ai.Embedder {
+	return genkit.LookupEmbedder(g, provider, name)
 }

--- a/go/plugins/compat_oai/openai/openai_live_test.go
+++ b/go/plugins/compat_oai/openai/openai_live_test.go
@@ -32,6 +32,28 @@ func TestPlugin(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log("openai plugin initialized")
+
+	t.Run("embedder", func(t *testing.T) {
+		embedder := openai.Embedder(g, "text-embedding-3-small")
+		res, err := ai.Embed(ctx, embedder, ai.WithEmbedText("yellow banana"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := res.Embeddings[0].Embedding
+		// There's not a whole lot we can test about the result.
+		// Just do a few sanity checks.
+		if len(out) < 100 {
+			t.Errorf("embedding vector looks too short: len(out)=%d", len(out))
+		}
+		var normSquared float32
+		for _, x := range out {
+			normSquared += x * x
+		}
+		if normSquared < 0.9 || normSquared > 1.1 {
+			t.Errorf("embedding vector not unit length: %f", normSquared)
+		}
+	})
+
 	t.Run("basic completion", func(t *testing.T) {
 		t.Log("generating basic completion response")
 		resp, err := genkit.Generate(ctx, g,


### PR DESCRIPTION
Added embedding support similar to [here](https://github.com/yukinagae/genkit-go-plugins/blob/fe8963d877b863c9acacf66bc179e3327cb7d93b/plugins/openai/openai.go#L144)

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.): `go test -run "TestPlugin/embedder"`
- [ ] Docs updated (updated docs or a docs bug required)
