### PR TITLE
feat(go): add Anthropic models

### DIFF
--- a/go/plugins/compat_oai/anthropic/README.md
+++ b/go/plugins/compat_oai/anthropic/README.md
@@ -1,0 +1,53 @@
+# Anthropic Plugin
+
+This plugin provides a simple interface for using Anthropic's services.
+
+## Prerequisites
+
+- Go installed on your system
+- An Anthropic API key
+
+## Running Tests
+
+First, set your Anthropic API key as an environment variable:
+
+```bash
+export ANTHROPIC_API_KEY=<your-api-key>
+```
+
+### Running All Tests
+To run all tests in the directory:
+```bash
+go test -v .
+```
+
+### Running Tests from Specific Files
+To run tests from a specific file:
+```bash
+# Run only generate_live_test.go tests
+go test -run "^TestGenerator"
+
+# Run only anthropic_live_test.go tests
+go test -run "^TestPlugin"
+```
+
+### Running Individual Tests
+To run a specific test case:
+```bash
+# Run only the streaming test from anthropic_live_test.go
+go test -run "TestPlugin/streaming"
+
+# Run only the Complete test from generate_live_test.go
+go test -run "TestGenerator_Complete"
+
+# Run only the Stream test from generate_live_test.go
+go test -run "TestGenerator_Stream"
+```
+
+### Test Output Verbosity
+Add the `-v` flag for verbose output:
+```bash
+go test -v -run "TestPlugin/streaming"
+```
+
+Note: All live tests require the ANTHROPIC_API_KEY environment variable to be set. Tests will be skipped if the API key is not provided.

--- a/go/plugins/compat_oai/anthropic/anthropic.go
+++ b/go/plugins/compat_oai/anthropic/anthropic.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"context"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go/option"
+)
+
+const provider = "anthropic"
+
+var (
+	// Supported models: https://docs.anthropic.com/en/docs/about-claude/models/all-models
+	supportedModels = map[string]ai.ModelInfo{
+		"claude-3-7-sonnet-20250219": {
+			Label: "Claude 3.7 Sonnet",
+			Supports: &ai.ModelSupports{
+				Multiturn:  true,
+				Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
+				SystemRole: true,
+				Media:      true,
+			},
+			Versions: []string{"claude-3-7-sonnet-latest", "claude-3-7-sonnet-20250219"},
+		},
+		"claude-3-5-haiku-20241022": {
+			Label: "Claude 3.5 Haiku",
+			Supports: &ai.ModelSupports{
+				Multiturn:  true,
+				Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
+				SystemRole: true,
+				Media:      true,
+			},
+			Versions: []string{"claude-3-5-haiku-latest", "claude-3-5-haiku-20241022"},
+		},
+		"claude-3-5-sonnet-20240620": {
+			Label: "Claude 3.5 Sonnet",
+			Supports: &ai.ModelSupports{
+				Multiturn:  true,
+				Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
+				SystemRole: false, // NOTE: This model does not support system role
+				Media:      true,
+			},
+			Versions: []string{"claude-3-5-sonnet-20240620"},
+		},
+		"claude-3-opus-20240229": {
+			Label: "Claude 3 Opus",
+			Supports: &ai.ModelSupports{
+				Multiturn:  true,
+				Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
+				SystemRole: false, // NOTE: This model does not support system role
+				Media:      true,
+			},
+			Versions: []string{"claude-3-opus-latest", "claude-3-opus-20240229"},
+		},
+		"claude-3-haiku-20240307": {
+			Label: "Claude 3 Haiku",
+			Supports: &ai.ModelSupports{
+				Multiturn:  true,
+				Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
+				SystemRole: false, // NOTE: This model does not support system role
+				Media:      true,
+			},
+			Versions: []string{"claude-3-haiku-20240307"},
+		},
+	}
+)
+
+type Anthropic struct {
+	Opts             []option.RequestOption
+	openAICompatible compat_oai.OpenAICompatible
+}
+
+// Name implements genkit.Plugin.
+func (a *Anthropic) Name() string {
+	return provider
+}
+
+func (a *Anthropic) Init(ctx context.Context, g *genkit.Genkit) error {
+	// initialize OpenAICompatible
+	a.openAICompatible.Opts = a.Opts
+	if err := a.openAICompatible.Init(ctx, g); err != nil {
+		return err
+	}
+
+	// define default models
+	for model, info := range supportedModels {
+		if _, err := a.DefineModel(g, model, info); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *Anthropic) Model(g *genkit.Genkit, name string) ai.Model {
+	return a.openAICompatible.Model(g, name, provider)
+}
+
+func (a *Anthropic) DefineModel(g *genkit.Genkit, name string, info ai.ModelInfo) (ai.Model, error) {
+	return a.openAICompatible.DefineModel(g, name, provider, info)
+}

--- a/go/plugins/compat_oai/anthropic/anthropic.go
+++ b/go/plugins/compat_oai/anthropic/anthropic.go
@@ -23,7 +23,10 @@ import (
 	"github.com/openai/openai-go/option"
 )
 
-const provider = "anthropic"
+const (
+	provider = "anthropic"
+	baseURL  = "https://api.anthropic.com/v1"
+)
 
 var (
 	// Supported models: https://docs.anthropic.com/en/docs/about-claude/models/all-models
@@ -92,6 +95,9 @@ func (a *Anthropic) Name() string {
 }
 
 func (a *Anthropic) Init(ctx context.Context, g *genkit.Genkit) error {
+	// Set the base URL
+	a.Opts = append(a.Opts, option.WithBaseURL(baseURL))
+
 	// initialize OpenAICompatible
 	a.openAICompatible.Opts = a.Opts
 	if err := a.openAICompatible.Init(ctx, g); err != nil {

--- a/go/plugins/compat_oai/anthropic/anthropic_live_test.go
+++ b/go/plugins/compat_oai/anthropic/anthropic_live_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
+	"github.com/openai/openai-go/option"
+)
+
+func TestPlugin(t *testing.T) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("Skipping test: ANTHROPIC_API_KEY environment variable not set")
+	}
+
+	ctx := context.Background()
+
+	// Initialize genkit with claude-3-7-sonnet as default model
+	g, err := genkit.Init(
+		ctx,
+		genkit.WithDefaultModel("anthropic/claude-3-7-sonnet-20250219"),
+		genkit.WithPlugins(&anthropic.Anthropic{
+			Opts: []option.RequestOption{
+				option.WithAPIKey(apiKey),
+				option.WithBaseURL("https://api.anthropic.com/v1/"),
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("genkit initialized")
+
+	t.Run("basic completion", func(t *testing.T) {
+		t.Log("generating basic completion response")
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithPromptText("What is the capital of France?"),
+		)
+		if err != nil {
+			t.Fatal("error generating basic completion response: ", err)
+		}
+		t.Logf("basic completion response: %+v", resp)
+
+		out := resp.Message.Content[0].Text
+		if !strings.Contains(strings.ToLower(out), "paris") {
+			t.Errorf("got %q, expecting it to contain 'Paris'", out)
+		}
+
+		// Verify usage statistics are present
+		if resp.Usage == nil || resp.Usage.TotalTokens == 0 {
+			t.Error("Expected non-zero usage statistics")
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		var streamedOutput string
+		chunks := 0
+
+		final, err := genkit.Generate(ctx, g,
+			ai.WithPromptText("Write a short paragraph about artificial intelligence."),
+			ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
+				chunks++
+				for _, content := range chunk.Content {
+					streamedOutput += content.Text
+				}
+				return nil
+			}))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify streaming worked
+		if chunks <= 1 {
+			t.Error("Expected multiple chunks for streaming")
+		}
+
+		// Verify final output matches streamed content
+		finalOutput := ""
+		for _, content := range final.Message.Content {
+			finalOutput += content.Text
+		}
+		if streamedOutput != finalOutput {
+			t.Errorf("Streaming output doesn't match final output\nStreamed: %s\nFinal: %s",
+				streamedOutput, finalOutput)
+		}
+
+		t.Logf("streaming response: %+v", finalOutput)
+	})
+
+	t.Run("system message", func(t *testing.T) {
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithPromptText("What are you?"),
+			ai.WithSystemText("You are a helpful math tutor who loves numbers."),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out := resp.Message.Content[0].Text
+		if !strings.Contains(strings.ToLower(out), "math") {
+			t.Errorf("got %q, expecting response to mention being a math tutor", out)
+		}
+
+		t.Logf("system message response: %+v", out)
+	})
+}

--- a/go/plugins/compat_oai/anthropic/anthropic_live_test.go
+++ b/go/plugins/compat_oai/anthropic/anthropic_live_test.go
@@ -41,7 +41,6 @@ func TestPlugin(t *testing.T) {
 		genkit.WithPlugins(&anthropic.Anthropic{
 			Opts: []option.RequestOption{
 				option.WithAPIKey(apiKey),
-				option.WithBaseURL("https://api.anthropic.com/v1/"),
 			},
 		}),
 	)

--- a/go/samples/compat_oai/anthropic/main.go
+++ b/go/samples/compat_oai/anthropic/main.go
@@ -28,7 +28,6 @@ func main() {
 	oai := oai.Anthropic{
 		Opts: []option.RequestOption{
 			option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
-			option.WithBaseURL("https://api.anthropic.com/v1/"),
 		},
 	}
 	g, err := genkit.Init(ctx, genkit.WithPlugins(&oai))

--- a/go/samples/compat_oai/anthropic/main.go
+++ b/go/samples/compat_oai/anthropic/main.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
-	"github.com/firebase/genkit/go/plugins/compat_oai"
+	oai "github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
 	"github.com/firebase/genkit/go/plugins/server"
 	"github.com/openai/openai-go/option"
 )
@@ -25,12 +25,11 @@ import (
 func main() {
 	ctx := context.Background()
 
-	oai := compat_oai.OpenAICompatible{
+	oai := oai.Anthropic{
 		Opts: []option.RequestOption{
 			option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
 			option.WithBaseURL("https://api.anthropic.com/v1/"),
 		},
-		Provider: "anthropic",
 	}
 	g, err := genkit.Init(ctx, genkit.WithPlugins(&oai))
 	if err != nil {
@@ -38,11 +37,8 @@ func main() {
 	}
 
 	genkit.DefineFlow(g, "anthropic", func(ctx context.Context, subject string) (string, error) {
+		sonnet37 := oai.Model(g, "claude-3-7-sonnet-20250219")
 
-		sonnet37, err := oai.DefineModel(g, "claude-3-7-sonnet-20250219", "anthropic", ai.ModelInfo{Label: "Claude Sonnet", Supports: compat_oai.Multimodal.Supports})
-		if err != nil {
-			return "", err
-		}
 		prompt := fmt.Sprintf("tell me a joke about %s", subject)
 		foo, err := genkit.Generate(ctx, g, ai.WithModel(sonnet37), ai.WithPromptText(prompt))
 		if err != nil {


### PR DESCRIPTION
Support Anthropic models:
- claude-3-7-sonnet
- claude-3-5-haiku
- claude-3-5-sonnet
- claude-3-opus
- claude-3-haiku

see: https://docs.anthropic.com/en/api/openai-sdk

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)

TODO

- [x] Add model details and versions
