### PR TITLE
fix: adds genkit common config to openai plugin

### DIFF
--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -1,0 +1,67 @@
+# OpenAI-Compatible Plugin Package
+
+This directory contains a package for building plugins that are compatible with the OpenAI API specification, along with plugins built on top of this package. 
+
+## Package Overview
+
+The `compat_oai` package provides a base implementation (`OpenAICompatible`) that handles:
+- Model and embedder registration
+- Message handling
+- Tool support
+- Configuration management
+
+## Usage Example
+
+Here's how to implement a new OpenAI-compatible plugin:
+
+```go
+type MyPlugin struct {
+    compat_oai.OpenAICompatible
+    // define other plugin-specific fields
+}
+
+func NewPlugin(apiKey string) *MyPlugin {
+    return &MyPlugin{
+        OpenAICompatible: compat_oai.OpenAICompatible{
+            Opts:     []option.RequestOption{option.WithAPIKey(apiKey)},
+            Provider: "myprovider",
+        },
+        // initialize other fields
+    }
+}
+
+// Implement required methods
+func (p *MyPlugin) Init(ctx context.Context, g *genkit.Genkit) error {
+    return p.OpenAICompatible.Init(ctx, g)
+}
+
+func (p *MyPlugin) Name() string {
+    return p.Provider
+}
+```
+
+See the `openai` and `anthropic` directories for complete implementations.
+
+## Running Tests
+
+Set your API keys:
+```bash
+export OPENAI_API_KEY=<your-openai-key>
+export ANTHROPIC_API_KEY=<your-anthropic-key>
+```
+
+Run all tests:
+```bash
+go test -v ./...
+```
+
+Run specific plugin tests:
+```bash
+# OpenAI tests
+go test -v ./openai
+
+# Anthropic tests
+go test -v ./anthropic
+```
+
+Note: Tests will be skipped if the required API keys are not set.

--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -20,6 +20,12 @@ type MyPlugin struct {
     // define other plugin-specific fields
 }
 
+var (
+    supportedModels = map[string]ai.ModelInfo{
+        // define supported models
+    }
+)
+
 func NewPlugin(apiKey string) *MyPlugin {
     return &MyPlugin{
         OpenAICompatible: compat_oai.OpenAICompatible{
@@ -32,7 +38,21 @@ func NewPlugin(apiKey string) *MyPlugin {
 
 // Implement required methods
 func (p *MyPlugin) Init(ctx context.Context, g *genkit.Genkit) error {
-    return p.OpenAICompatible.Init(ctx, g)
+    // initialize the plugin with the common compatible package
+    if err := p.OpenAICompatible.Init(ctx, g); err != nil {
+        return err
+    }
+
+    // Define plugin-specific models
+    for model, info := range supportedModels {
+        if _, err := p.DefineModel(g, p.Provider, model, info); err != nil {
+            return err
+        }
+    }
+
+    // Define embedders, if applicable
+
+    return nil
 }
 
 func (p *MyPlugin) Name() string {

--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -26,16 +26,6 @@ var (
     }
 )
 
-func NewPlugin(apiKey string) *MyPlugin {
-    return &MyPlugin{
-        OpenAICompatible: compat_oai.OpenAICompatible{
-            Opts:     []option.RequestOption{option.WithAPIKey(apiKey)},
-            Provider: "myprovider",
-        },
-        // initialize other fields
-    }
-}
-
 // Implement required methods
 func (p *MyPlugin) Init(ctx context.Context, g *genkit.Genkit) error {
     // initialize the plugin with the common compatible package

--- a/go/plugins/compat_oai/anthropic/anthropic.go
+++ b/go/plugins/compat_oai/anthropic/anthropic.go
@@ -119,5 +119,5 @@ func (a *Anthropic) Model(g *genkit.Genkit, name string) ai.Model {
 }
 
 func (a *Anthropic) DefineModel(g *genkit.Genkit, name string, info ai.ModelInfo) (ai.Model, error) {
-	return a.openAICompatible.DefineModel(g, name, provider, info)
+	return a.openAICompatible.DefineModel(g, provider, name, info)
 }

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -52,10 +52,24 @@ var (
 // OpenAICompatible is a plugin that provides compatibility with OpenAI's Compatible APIs.
 // It allows defining models and embedders that can be used with Genkit.
 type OpenAICompatible struct {
-	mu       sync.Mutex
-	initted  bool
-	client   *openaiGo.Client
-	Opts     []option.RequestOption
+	// mu protects concurrent access to the client and initialization state
+	mu sync.Mutex
+
+	// initted tracks whether the plugin has been initialized
+	initted bool
+
+	// client is the OpenAI client used for making API requests
+	// see https://github.com/openai/openai-go
+	client *openaiGo.Client
+
+	// Opts contains request options for the OpenAI client.
+	// Required: Must include at least WithAPIKey for authentication.
+	// Optional: Can include other options like WithOrganization, WithBaseURL, etc.
+	Opts []option.RequestOption
+
+	// Provider is a unique identifier for the plugin.
+	// This will be used as a prefix for model names (e.g., "myprovider/model-name").
+	// Should be lowercase and match the plugin's Name() method.
 	Provider string
 }
 

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -81,7 +81,7 @@ func (o *OpenAICompatible) Name() string {
 }
 
 // DefineModel defines a model in the registry
-func (o *OpenAICompatible) DefineModel(g *genkit.Genkit, name, provider string, info ai.ModelInfo) (ai.Model, error) {
+func (o *OpenAICompatible) DefineModel(g *genkit.Genkit, provider, name string, info ai.ModelInfo) (ai.Model, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if !o.initted {
@@ -111,7 +111,7 @@ func (o *OpenAICompatible) DefineModel(g *genkit.Genkit, name, provider string, 
 }
 
 // DefineEmbedder defines an embedder with a given name.
-func (o *OpenAICompatible) DefineEmbedder(g *genkit.Genkit, name string, provider string) (ai.Embedder, error) {
+func (o *OpenAICompatible) DefineEmbedder(g *genkit.Genkit, provider, name string) (ai.Embedder, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if !o.initted {

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -135,15 +135,15 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 		return g
 	}
 
-	var openaiConfig OpenaiConfig
+	var openaiConfig OpenAIConfig
 	switch cfg := config.(type) {
-	case OpenaiConfig:
+	case OpenAIConfig:
 		openaiConfig = cfg
-	case *OpenaiConfig:
+	case *OpenAIConfig:
 		openaiConfig = *cfg
 	case map[string]any:
 		if err := mapToStruct(cfg, &openaiConfig); err != nil {
-			g.err = fmt.Errorf("failed to convert config to OpenaiConfig: %w", err)
+			g.err = fmt.Errorf("failed to convert config to OpenAIConfig: %w", err)
 			return g
 		}
 	default:

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -120,7 +120,7 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 
 	// Map fields explicitly from genkit common config to OpenAI config in request
 	if cfg.MaxOutputTokens != 0 {
-		g.request.MaxTokens = openai.F(int64(cfg.MaxOutputTokens))
+		g.request.MaxCompletionTokens = openai.F(int64(cfg.MaxOutputTokens))
 	}
 	if len(cfg.StopSequences) > 0 {
 		g.request.Stop = openai.F[openai.ChatCompletionNewParamsStopUnion](

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -111,7 +111,7 @@ func (g *ModelGenerator) WithMessages(messages []*ai.Message) *ModelGenerator {
 }
 
 // OpenaiConfig mirrors the OpenAI API configuration fields
-type OpenaiConfig struct {
+type OpenAIConfig struct {
 	// Maximum number of tokens to generate
 	MaxOutputTokens int `json:"max_output_tokens,omitempty"`
 	// Temperature for sampling

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -33,22 +33,8 @@ type ModelGenerator struct {
 	err error
 }
 
-func (g *ModelGenerator) GetRequestConfig() *openai.ChatCompletionNewParams {
+func (g *ModelGenerator) GetRequest() *openai.ChatCompletionNewParams {
 	return g.request
-}
-
-func (g *ModelGenerator) TransformToGenkitGenerationCommonConfig(cfg *openai.ChatCompletionNewParams) *ai.GenerationCommonConfig {
-	// Transform the OpenAI config to Genkit config
-	if cfg == nil {
-		return nil
-	}
-
-	return &ai.GenerationCommonConfig{
-		Temperature:     cfg.Temperature.Value,
-		MaxOutputTokens: int(cfg.MaxTokens.Value),
-		TopP:            cfg.TopP.Value,
-		Version:         cfg.Model.Value,
-	}
 }
 
 // NewModelGenerator creates a new ModelGenerator instance
@@ -128,7 +114,7 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 
 	cfg, ok := config.(*ai.GenerationCommonConfig)
 	if !ok {
-		g.err = fmt.Errorf("config must be a pointer to ai.GenerationCommonConfig")
+		g.err = fmt.Errorf("config must be of type *ai.GenerationCommonConfig")
 		return g
 	}
 

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -102,6 +102,8 @@ func (g *ModelGenerator) WithMessages(messages []*ai.Message) *ModelGenerator {
 }
 
 // WithConfig adds configuration parameters from the model request
+// see https://platform.openai.com/docs/api-reference/responses/create
+// for more details on openai's request fields
 func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 	// Return early if we already have an error
 	if g.err != nil {

--- a/go/plugins/compat_oai/generate_live_test.go
+++ b/go/plugins/compat_oai/generate_live_test.go
@@ -131,7 +131,7 @@ func TestWithConfig(t *testing.T) {
 		},
 		{
 			name:   "empty openai config",
-			config: compat_oai.OpenaiConfig{},
+			config: compat_oai.OpenAIConfig{},
 			validate: func(t *testing.T, request *openaiClient.ChatCompletionNewParams) {
 				// For empty config, we expect all fields to be unset
 				assert.False(t, request.Temperature.Present)
@@ -142,7 +142,7 @@ func TestWithConfig(t *testing.T) {
 		},
 		{
 			name: "valid config with all supported fields",
-			config: compat_oai.OpenaiConfig{
+			config: compat_oai.OpenAIConfig{
 				Temperature:     0.7,
 				MaxOutputTokens: 100,
 				TopP:            0.9,

--- a/go/plugins/compat_oai/generate_live_test.go
+++ b/go/plugins/compat_oai/generate_live_test.go
@@ -124,7 +124,7 @@ func TestWithConfig(t *testing.T) {
 			validate: func(t *testing.T, request *openaiClient.ChatCompletionNewParams) {
 				// For nil config, we expect all fields to be unset (not nil, but with Present=false)
 				assert.False(t, request.Temperature.Present)
-				assert.False(t, request.MaxTokens.Present)
+				assert.False(t, request.MaxCompletionTokens.Present)
 				assert.False(t, request.TopP.Present)
 				assert.False(t, request.Stop.Present)
 			},
@@ -135,7 +135,7 @@ func TestWithConfig(t *testing.T) {
 			validate: func(t *testing.T, request *openaiClient.ChatCompletionNewParams) {
 				// For empty config, we expect all fields to be unset
 				assert.False(t, request.Temperature.Present)
-				assert.False(t, request.MaxTokens.Present)
+				assert.False(t, request.MaxCompletionTokens.Present)
 				assert.False(t, request.TopP.Present)
 				assert.False(t, request.Stop.Present)
 			},
@@ -153,8 +153,8 @@ func TestWithConfig(t *testing.T) {
 				assert.True(t, request.Temperature.Present)
 				assert.Equal(t, float64(0.7), request.Temperature.Value)
 
-				assert.True(t, request.MaxTokens.Present)
-				assert.Equal(t, int64(100), request.MaxTokens.Value)
+				assert.True(t, request.MaxCompletionTokens.Present)
+				assert.Equal(t, int64(100), request.MaxCompletionTokens.Value)
 
 				assert.True(t, request.TopP.Present)
 				assert.Equal(t, float64(0.9), request.TopP.Value)

--- a/go/plugins/compat_oai/openai/README.md
+++ b/go/plugins/compat_oai/openai/README.md
@@ -7,6 +7,33 @@ This plugin provides a simple interface for using OpenAI's services.
 - Go installed on your system
 - An OpenAI API key
 
+## Usage
+
+Here's a simple example of how to use the OpenAI plugin:
+
+```go
+// Initialize the OpenAI plugin with your API key
+oai := openai.NewPlugin(apiKey)
+
+// Initialize Genkit with the OpenAI plugin
+g, err := genkit.Init(ctx,
+    genkit.WithDefaultModel("openai/gpt-4o-mini"),
+    genkit.WithPlugins(oai),
+)
+if err != nil {
+    // hanlde errors
+}
+
+config := &ai.GenerationCommonConfig{
+    // define config fields
+}
+
+resp, err = genkit.Generate(ctx, g,
+    ai.WithPromptText("Write a short sentence about artificial intelligence."),
+    ai.WithConfig(config),
+)
+```
+
 ## Running Tests
 
 First, set your OpenAI API key as an environment variable:

--- a/go/plugins/compat_oai/openai/README.md
+++ b/go/plugins/compat_oai/openai/README.md
@@ -12,6 +12,7 @@ This plugin provides a simple interface for using OpenAI's services.
 Here's a simple example of how to use the OpenAI plugin:
 
 ```go
+// import "github.com/firebase/genkit/go/plugins/compat_oai/openai"
 // Initialize the OpenAI plugin with your API key
 oai := openai.NewPlugin(apiKey)
 
@@ -25,7 +26,7 @@ if err != nil {
 }
 
 config := &ai.GenerationCommonConfig{
-    // define config fields
+    // define optional config fields
 }
 
 resp, err = genkit.Generate(ctx, g,

--- a/go/plugins/compat_oai/openai/README.md
+++ b/go/plugins/compat_oai/openai/README.md
@@ -22,7 +22,7 @@ g, err := genkit.Init(ctx,
     genkit.WithPlugins(oai),
 )
 if err != nil {
-    // hanlde errors
+    // handle errors
 }
 
 config := &ai.GenerationCommonConfig{

--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -155,6 +155,10 @@ func (o *OpenAI) Init(ctx context.Context, g *genkit.Genkit) error {
 		return fmt.Errorf("openai plugin initialization failed: apiKey is required")
 	}
 
+	if o.openAICompatible == nil {
+		o.openAICompatible = &compat_oai.OpenAICompatible{}
+	}
+
 	// set the options
 	o.openAICompatible.Opts = []option.RequestOption{
 		option.WithAPIKey(apiKey),

--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -164,11 +164,11 @@ func (o *OpenAI) Model(g *genkit.Genkit, name string) ai.Model {
 }
 
 func (o *OpenAI) DefineModel(g *genkit.Genkit, name string, info ai.ModelInfo) (ai.Model, error) {
-	return o.openAICompatible.DefineModel(g, name, provider, info)
+	return o.openAICompatible.DefineModel(g, provider, name, info)
 }
 
 func (o *OpenAI) DefineEmbedder(g *genkit.Genkit, name string) (ai.Embedder, error) {
-	return o.openAICompatible.DefineEmbedder(g, name, provider)
+	return o.openAICompatible.DefineEmbedder(g, provider, name)
 }
 
 func (o *OpenAI) Embedder(g *genkit.Genkit, name string) ai.Embedder {

--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -126,22 +126,10 @@ var (
 )
 
 type OpenAI struct {
-	// apiKey is the API key for the OpenAI API.
+	// APIKey is the API key for the OpenAI API.
 	// request a key at https://platform.openai.com/api-keys
-	apiKey           string
+	APIKey           string
 	openAICompatible *compat_oai.OpenAICompatible
-}
-
-// NewPlugin creates a new OpenAI plugin with the given API key.
-func NewPlugin(apiKey string) *OpenAI {
-	return &OpenAI{
-		apiKey: apiKey,
-		openAICompatible: &compat_oai.OpenAICompatible{
-			Opts: []option.RequestOption{
-				option.WithAPIKey(apiKey),
-			},
-		},
-	}
 }
 
 // Name implements genkit.Plugin.
@@ -151,12 +139,12 @@ func (o *OpenAI) Name() string {
 
 // Init implements genkit.Plugin.
 func (o *OpenAI) Init(ctx context.Context, g *genkit.Genkit) error {
-	if o.apiKey == "" {
+	if o.APIKey == "" {
 		return fmt.Errorf("openai plugin initialization failed: apiKey is required")
 	}
 	// set the API key
 	o.openAICompatible.Opts = []option.RequestOption{
-		option.WithAPIKey(o.apiKey),
+		option.WithAPIKey(o.APIKey),
 	}
 	if err := o.openAICompatible.Init(ctx, g); err != nil {
 		return err

--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -128,10 +128,10 @@ var (
 
 type OpenAI struct {
 	// APIKey is the API key for the OpenAI API. If empty, the values of the environment variable "OPENAI_API_KEY" will be consulted.
-	// request a key at https://platform.openai.com/api-keys
+	// Request a key at https://platform.openai.com/api-keys
 	APIKey string
-	// Opts are additional options for the OpenAI client.
-	// Optional: Can include other options like WithOrganization, WithBaseURL, etc.
+	// Optional: Opts are additional options for the OpenAI client.
+	// Can include other options like WithOrganization, WithBaseURL, etc.
 	Opts []option.RequestOption
 
 	openAICompatible *compat_oai.OpenAICompatible

--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -16,6 +16,7 @@ package openai
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
@@ -125,8 +126,22 @@ var (
 )
 
 type OpenAI struct {
-	Opts             []option.RequestOption
-	openAICompatible compat_oai.OpenAICompatible
+	// apiKey is the API key for the OpenAI API.
+	// request a key at https://platform.openai.com/api-keys
+	apiKey           string
+	openAICompatible *compat_oai.OpenAICompatible
+}
+
+// NewPlugin creates a new OpenAI plugin with the given API key.
+func NewPlugin(apiKey string) *OpenAI {
+	return &OpenAI{
+		apiKey: apiKey,
+		openAICompatible: &compat_oai.OpenAICompatible{
+			Opts: []option.RequestOption{
+				option.WithAPIKey(apiKey),
+			},
+		},
+	}
 }
 
 // Name implements genkit.Plugin.
@@ -136,8 +151,13 @@ func (o *OpenAI) Name() string {
 
 // Init implements genkit.Plugin.
 func (o *OpenAI) Init(ctx context.Context, g *genkit.Genkit) error {
-	// initialize OpenAICompatible
-	o.openAICompatible.Opts = o.Opts
+	if o.apiKey == "" {
+		return fmt.Errorf("openai plugin initialization failed: apiKey is required")
+	}
+	// set the API key
+	o.openAICompatible.Opts = []option.RequestOption{
+		option.WithAPIKey(o.apiKey),
+	}
 	if err := o.openAICompatible.Init(ctx, g); err != nil {
 		return err
 	}

--- a/go/plugins/compat_oai/openai/openai_live_test.go
+++ b/go/plugins/compat_oai/openai/openai_live_test.go
@@ -35,7 +35,9 @@ func TestPlugin(t *testing.T) {
 	ctx := context.Background()
 
 	// Initialize the OpenAI plugin
-	oai := openai.NewPlugin(apiKey)
+	oai := &openai.OpenAI{
+		APIKey: apiKey,
+	}
 	g, err := genkit.Init(context.Background(),
 		genkit.WithDefaultModel("openai/gpt-4o-mini"),
 		genkit.WithPlugins(oai),

--- a/go/plugins/compat_oai/openai/openai_live_test.go
+++ b/go/plugins/compat_oai/openai/openai_live_test.go
@@ -211,4 +211,31 @@ func TestPlugin(t *testing.T) {
 
 		t.Logf("system message response: %+v", out)
 	})
+
+	t.Run("generation config", func(t *testing.T) {
+		// Create a config with specific parameters
+		config := &ai.GenerationCommonConfig{
+			Temperature:     0.2,
+			MaxOutputTokens: 50,
+			TopP:            0.5,
+			StopSequences:   []string{".", "!", "?"},
+		}
+
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithPromptText("Write a short sentence about artificial intelligence."),
+			ai.WithConfig(config),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out := resp.Message.Content[0].Text
+
+		// Verify the response is short (due to MaxOutputTokens)
+		if len(out) > 100 {
+			t.Errorf("response too long (got %d chars), expected shorter response due to MaxOutputTokens", len(out))
+		}
+
+		t.Logf("generation config response: %+v", out)
+	})
 }

--- a/go/plugins/compat_oai/openai/openai_live_test.go
+++ b/go/plugins/compat_oai/openai/openai_live_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/openai"
-	"github.com/openai/openai-go/option"
 )
 
 func TestPlugin(t *testing.T) {
@@ -36,13 +35,10 @@ func TestPlugin(t *testing.T) {
 	ctx := context.Background()
 
 	// Initialize the OpenAI plugin
-	apiKeyOption := option.WithAPIKey(apiKey)
-	oai := openai.OpenAI{
-		Opts: []option.RequestOption{apiKeyOption},
-	}
+	oai := openai.NewPlugin(apiKey)
 	g, err := genkit.Init(context.Background(),
 		genkit.WithDefaultModel("openai/gpt-4o-mini"),
-		genkit.WithPlugins(&oai),
+		genkit.WithPlugins(oai),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/go/samples/compat_oai/openai/main.go
+++ b/go/samples/compat_oai/openai/main.go
@@ -20,18 +20,17 @@ import (
 	oai "github.com/firebase/genkit/go/plugins/compat_oai/openai"
 	"github.com/firebase/genkit/go/plugins/server"
 	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
 )
 
 func main() {
 	ctx := context.Background()
 
-	oai := oai.OpenAI{
-		Opts: []option.RequestOption{
-			option.WithAPIKey(os.Getenv("OPENAI_API_KEY")),
-		},
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		log.Fatalf("no OPENAI_API_KEY environment variable set")
 	}
-	g, err := genkit.Init(ctx, genkit.WithPlugins(&oai))
+	oai := oai.NewPlugin(apiKey)
+	g, err := genkit.Init(ctx, genkit.WithPlugins(oai))
 	if err != nil {
 		log.Fatalf("failed to create Genkit: %v", err)
 	}

--- a/go/samples/compat_oai/openai/main.go
+++ b/go/samples/compat_oai/openai/main.go
@@ -29,7 +29,9 @@ func main() {
 	if apiKey == "" {
 		log.Fatalf("no OPENAI_API_KEY environment variable set")
 	}
-	oai := oai.NewPlugin(apiKey)
+	oai := &oai.OpenAI{
+		APIKey: apiKey,
+	}
 	g, err := genkit.Init(ctx, genkit.WithPlugins(oai))
 	if err != nil {
 		log.Fatalf("failed to create Genkit: %v", err)


### PR DESCRIPTION
Adds the genkit common config to use in the openai compatible plugin. Additionally, adds a simplified helper method to the openai plugin and updated documentation.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)